### PR TITLE
Modify benchmark action to only generate data

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,9 @@
 name: Run benchmarks
 on:
   schedule:
-    # Run every day at midnight.
-    - cron: "0 0 * * *"
+    # Run every day a bit after test262
+    - cron: "0 1 * * *"
+  workflow_dispatch:
 
 jobs:
   benchmark:
@@ -22,7 +23,6 @@ jobs:
         with:
           path: |
             boa/target
-            !boa/target/doc_upload
             ~boa/.cargo/git
             ~boa/.cargo/registry
           key: ${{ runner.os }}-cargo-doc-bench-${{ hashFiles('**/Cargo.lock') }}
@@ -33,12 +33,26 @@ jobs:
       - name: Run benchmark
         run: |
           cd boa
-          cargo bench -p boa_engine -- --output-format bencher | tee ../data/output.txt
+          cargo bench -p boa_engine -- --output-format bencher | tee output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.19.3
         with:
           name: Boa Benchmarks
           tool: "cargo"
-          output-file-path: data/output.txt
-          auto-push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file-path: output.txt
+          external-data-json-path: ../data/bench/data.json
+          auto-push: false
+          skip-fetch-gh-pages: true
+      - name: Commit files
+        run: |
+          cd ../data
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add bench
+          git commit -m "Add new benchmark results" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          directory: data

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,12 @@
+# Cleaning up benchmarks
+
+We have noticed that sometimes we store empty benchmarks (should be solved now that we use the
+upstream action). And if we don't clean-up anything, old benchmarks will stay in the JSON file
+forever. In order to avoid this, you can use the `process.py` file.
+
+To use this, run the file `bench/process.py` from the repository root. This will create a
+`bench/data_processed.json` file. You will then just have to replace `bench/data.json` with the new
+file.
+
+While this is not very user friendly, it does the job, and hopefully we should just do it once in a
+while to clean-up old benchmarks.

--- a/bench/process.py
+++ b/bench/process.py
@@ -1,0 +1,57 @@
+import json
+from datetime import datetime, timezone
+
+def new_valid_bench(bench):
+    # This runs showed to be a clear outliers
+    outliers = [
+        "13df9a1984d729328fda88ca9432a84eb4990d3b",
+        "71daf2a06ca411ab821931d4202875be1b0b4026",
+        "518bad810974aa4cf6fcd3d864756f298d1b204d",
+        "39cd3b8bdffada751621132de1f8b65d04627d6d",
+        "a2a33e749fa201205bb10a828afd24a3919fb4d6",
+        "fcf456e5ded032841e9c89255ef820070e3120e1",
+        "099154cb34c4f7fec6cf8d45f1f96b6797e10dd4",
+        "b0cf873a466bf3c71d258b20c81103f1ca696e97",
+        "5f8912907cd0d07bdfc8e5796e078f0db11d2147",
+        "4f36b8350e5768af0a52d6585cce1a16615e0348",
+        "610cf2c3c8bb7145829fb35ec3038365950d650d",
+        "8da46a9d21dd154cf4509b74fae39fa7c51d478c",
+        "6de1d15974393d102d8f2919b9353f8073ca1986"
+    ]
+
+    date = datetime.strptime(bench["commit"]["timestamp"], "%Y-%m-%dT%H:%M:%S%z")
+    date_diff = now - date
+    diff_years = (date_diff.days + date_diff.seconds/86400)/365.2425
+
+    return diff_years < 1 and bench["commit"]["id"] not in outliers
+
+def relevant_bench(bench):
+    irrelevant_benches = [
+        "RegExp (Execution) #2",
+        "Expression (Parser)",
+        "Hello World (Parser)",
+        "Long file (Parser)",
+        "Goal Symbols (Parser)",
+    ]
+
+    return bench["name"] not in irrelevant_benches and "(Full)" not in bench["name"]
+
+def non_empty_name(bench):
+    return bench["name"] != ""
+
+def clean_bench(bench):
+    bench["benches"] = list(filter(relevant_bench, filter(non_empty_name, bench["benches"])))
+    return bench
+
+with open('./bench/data.json') as input_f:
+    data = json.load(input_f)
+    benches = data["entries"]["Boa Benchmarks"]
+
+    now = datetime.now(timezone.utc)
+    total = len(benches)
+    print("Benches: ", total)
+
+    data["entries"]["Boa Benchmarks"] = list(map(clean_bench, filter(new_valid_bench, benches)))
+
+    with open('./bench/data_processed.json', 'w') as output_f:
+        json.dump(data, output_f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
Hopefully this should fix the action.

I also changed the cron time to an hour later than the test262 action, to avoid pushing both commits at the same time.