### PR TITLE
Fix LibJS binary name

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Benchmarking LibJS
         run: |
           esvu install libjs
-          ./bin/serenity-js data/bench/bench-v8/combined.js > data/bench/libjs_results.txt
+          ./bin/ladybird-js data/bench/bench-v8/combined.js > data/bench/libjs_results.txt
 
       - name: Benchmarking Boa
         run: |


### PR DESCRIPTION
The benchmarks have been failing, because the LibJS binary was renamed, e.g. https://github.com/boa-dev/data/actions/runs/9815416366/job/27104400108