### PR TITLE
Using native cpu target in Boa builds

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       ESVU_PATH: ${{ github.workspace }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RUSTFLAGS: "-C target-cpu=native"
     steps:
       - name: Checkout the data repository
         uses: actions/checkout@v4
@@ -38,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-cargo-benchmarks-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
       - name: Install esvu
         run: |
           npm i -g github:CanadaHonk/esvu


### PR DESCRIPTION
As we build and run in the same job we can utilise native cpu target, which should generate more efficient cpu instructions. I'm open to discussion on this.

- Prettier ran on the node-version 