### PR TITLE
Switch back to upstream esvu

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: "24"
       - name: Install esvu
         run: |
-          npm i -g github:CanadaHonk/esvu
+          npm i -g esvu
 
       - name: Benchmarking duktape
         run: |


### PR DESCRIPTION
This effectively reverts 77236e457fb45647f2869a1387c24940e019268c, the fork we used has since been archived. This hopefully will resolve the recent CI failures caused by esvu being unable to install LibJS.