### PR TITLE
Disable LibJS to unbreak benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,10 +73,10 @@ jobs:
           chmod +x ./bin/kiesel
           ./bin/kiesel data/bench/bench-v8/combined.js > data/bench/kiesel_results.txt
 
-      - name: Benchmarking LibJS
-        run: |
-          esvu install libjs
-          ./bin/ladybird-js data/bench/bench-v8/combined.js > data/bench/libjs_results.txt
+      # - name: Benchmarking LibJS
+      #   run: |
+      #     esvu install libjs
+      #     ./bin/ladybird-js data/bench/bench-v8/combined.js > data/bench/libjs_results.txt
 
       - name: Benchmarking Boa
         run: |

--- a/bench/gather_results.mjs
+++ b/bench/gather_results.mjs
@@ -28,7 +28,15 @@ const time = new Date().getTime();
 
 // gather data from txt files
 engines.forEach((val, engine) => {
-  const results = fs.readFileSync(`./bench/${engine}_results.txt`).toString();
+  let results;
+  try {
+    results = fs.readFileSync(`./bench/${engine}_results.txt`).toString();
+  } catch {
+    for (const benchmark of benchmarks) {
+      val[engine][benchmark] = null;
+    }
+    return;
+  }
   const lines = results.split("\n");
   lines.forEach((line) => {
     const search = resultsRegex.exec(line);


### PR DESCRIPTION
Rather than losing weeks of data for all engines (it's been broken for 10 days now) let's just disable LibJS - clearly upstream doesn't care about these results.